### PR TITLE
fix yaml syntax

### DIFF
--- a/shila_theme.libraries.yml
+++ b/shila_theme.libraries.yml
@@ -1,5 +1,5 @@
 global-styling:
-  version: 1.x
+  version: 1.x
   css:
     theme:
       dist/css/base.css: {}


### PR DESCRIPTION
The Symfony YAML parser (which Drupal falls back on when the yaml extension isn't available) throws an error on the non-breaking space on macOS (seems to work fine on Linux). Replacing it with a regular space fixes it.